### PR TITLE
Fix incorrect relation annotations to match protocol described in paper

### DIFF
--- a/corpus/PPR_dev_corpus.txt
+++ b/corpus/PPR_dev_corpus.txt
@@ -1086,7 +1086,6 @@
 15975050	23	49	Gardenia jasminoides Ellis	Plant
 15975050	81	113	liver and gall bladder disorders	Negative_phenotype
 15975050	Decrease	0	8	Gardenia	Plant	81	113	liver and gall bladder disorders	Negative_phenotype
-15975050	Decrease	0	8	Gardenia	Plant	91	113	gall bladder disorders	Negative_phenotype
 15975050	Decrease	23	49	Gardenia jasminoides Ellis	Plant	81	113	liver and gall bladder disorders	Negative_phenotype
 
 15975050_3	It has been shown recently that geniposide, the main ingredient of Gardenia Fructus, exhibits the anti-tumor effect.
@@ -3229,7 +3228,6 @@
 24548119	65	101	acute and immunological inflammation	Negative_phenotype
 24548119	146	163	anti-inflammatory	Positive_phenotype
 24548119	Decrease	29	31	BE	Plant	65	101	acute and immunological inflammation	Negative_phenotype
-24548119	Decrease	29	31	BE	Plant	75	101	immunological inflammation	Negative_phenotype
 24548119	Increase	29	31	BE	Plant	146	163	anti-inflammatory	Positive_phenotype
 
 24624888_1	Artemisia capillaris inhibits atopic dermatitis-like skin lesions in Dermatophagoides farinae-sensitized Nc/Nga mice.

--- a/corpus/PPR_dev_corpus.txt
+++ b/corpus/PPR_dev_corpus.txt
@@ -3219,7 +3219,6 @@
 
 24548119_6	Moreover, BE administration markedly suppressed the increase of liver mRNA levels of iNOS, TNF-a, IL-1b and IL-6, and the protein levels of iNOS, TNF-a and NF-kB.
 24548119	10	12	BE	Plant
-
 24548119_7	In addition, liver malondialdehyde and NO contents were significantly reduced by BE treatment.
 24548119	81	83	BE	Plant
 

--- a/corpus/PPR_dev_corpus.txt
+++ b/corpus/PPR_dev_corpus.txt
@@ -3219,6 +3219,7 @@
 
 24548119_6	Moreover, BE administration markedly suppressed the increase of liver mRNA levels of iNOS, TNF-a, IL-1b and IL-6, and the protein levels of iNOS, TNF-a and NF-kB.
 24548119	10	12	BE	Plant
+
 24548119_7	In addition, liver malondialdehyde and NO contents were significantly reduced by BE treatment.
 24548119	81	83	BE	Plant
 

--- a/corpus/PPR_train_corpus.txt
+++ b/corpus/PPR_train_corpus.txt
@@ -1970,8 +1970,8 @@
 11819701	11	13	BR	Plant
 11819701	66	92	preneoplastic hepatic foci	Negative_phenotype
 11819701	124	145	hepato-carcinogenesis	Negative_phenotype
-11819701	Decrease	8	10	BR	Plant	63	89	preneoplastic hepatic foci	Negative_phenotype
-11819701	Decrease	8	10	BR	Plant	124	145	hepato-carcinogenesis	Negative_phenotype
+11819701	Decrease	11	13	BR	Plant	63	89	preneoplastic hepatic foci	Negative_phenotype
+11819701	Decrease	11	13	BR	Plant	124	145	hepato-carcinogenesis	Negative_phenotype
 
 11819701_9	Both CH(2)Cl(2) and H(2)O extracts from BR exerted anti-inflammatory effect in rats and mice.
 11819701	40	42	BR	Plant
@@ -6102,8 +6102,8 @@
 16306813	Decrease	35	50	Punica granatum	Plant	310	325	type 2 diabetes	Negative_phenotype
 16306813	Decrease	35	50	Punica granatum	Plant	330	337	obesity	Negative_phenotype
 16306813	Increase	59	62	PGF	Plant	73	86	anti-diabetic	Positive_phenotype
-16306813	Decrease	59	62	PGF	Plant	201	266	hyperglycemia, hyperlipidemia, and fatty heart in Zucker diabetic	Negative_phenotype
-16306813	Decrease	59	62	PGF	Plant	216	266	hyperlipidemia, and fatty heart in Zucker diabetic	Negative_phenotype
+16306813	Decrease	59	62	PGF	Plant	201	214	hyperglycemia	Negative_phenotype
+16306813	Decrease	59	62	PGF	Plant	216	230	hyperlipidemia	Negative_phenotype
 16306813	Decrease	59	62	PGF	Plant	236	266	fatty heart in Zucker diabetic	Negative_phenotype
 16306813	Decrease	59	62	PGF	Plant	274	277	ZDF	Negative_phenotype
 16306813	Decrease	59	62	PGF	Plant	310	325	type 2 diabetes	Negative_phenotype
@@ -7164,7 +7164,6 @@
 16806112	34	41	Danggui	Plant
 16806112	77	120	cardiovascular and cerebrovascular diseases	Negative_phenotype
 16806112	Decrease	6	23	Angelica sinensis	Plant	77	120	cardiovascular and cerebrovascular diseases	Negative_phenotype
-16806112	Decrease	6	23	Angelica sinensis	Plant	96	120	cerebrovascular diseases	Negative_phenotype
 16806112	Decrease	34	41	Danggui	Plant	77	120	cardiovascular and cerebrovascular diseases	Negative_phenotype
 
 16806112_3	Modern phytochemical studies showed that Z-ligustilide (LIG) is the main lipophilic component of Danggui.

--- a/corpus/PPR_train_corpus.txt
+++ b/corpus/PPR_train_corpus.txt
@@ -1970,7 +1970,7 @@
 11819701	11	13	BR	Plant
 11819701	66	92	preneoplastic hepatic foci	Negative_phenotype
 11819701	124	145	hepato-carcinogenesis	Negative_phenotype
-11819701	Decrease	11	13	BR	Plant	63	89	preneoplastic hepatic foci	Negative_phenotype
+11819701	Decrease	11	13	BR	Plant	66	92	preneoplastic hepatic foci	Negative_phenotype
 11819701	Decrease	11	13	BR	Plant	124	145	hepato-carcinogenesis	Negative_phenotype
 
 11819701_9	Both CH(2)Cl(2) and H(2)O extracts from BR exerted anti-inflammatory effect in rats and mice.


### PR DESCRIPTION
Thanks for this useful dataset!

This pull request fixes (when possible) or deletes incorrect annotations in the dataset. Specifically, it addresses relation instances that are incorrect or do not match the protocol described in the paper. Specifically, it modifies the data in the following three cases:

Entity offsets listed in relation annotation do not match the offsets for the entity annotation (document_ids: 11819701_8; action: fix)
Multiple non-overlapping entities are listed as a single entity in the relation annotation, but the overlapping entity is not included in the entity list (document_ids: 16306813_4; action: fix)
A piece of a mention containing multiple overlapping entities is listed in the relation annotation, but this piece is not included in the list of entities (document ids: 16806112_2, 15975050_2, 24548119_8; action: delete)